### PR TITLE
use HTTPS and set secure cookies; show URL in emails; fixes #9659

### DIFF
--- a/app/views/fab_mailer/remind.html.erb
+++ b/app/views/fab_mailer/remind.html.erb
@@ -13,7 +13,7 @@
       Click through and let us know:
     </p>
     <p>
-      <%= link_to "Update your fab", user_fabs_url(@user) %>
+      <%= link_to nil, user_fabs_url(@user) %>
     </p>
   </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -82,7 +82,7 @@ Rails.application.configure do
   }
 
   # ActionMailer Config
-  config.action_mailer.default_url_options = { :host => ENV['domain_name'] }
+  config.action_mailer.default_url_options = { :host => ENV['domain_name'], :protocol => 'https' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This is untested but theoretically should work in production environment - our nginx is configured to send rails a `X-Forwarded-Proto: https` header.
