### PR TITLE
Fixes bug in caching for /users and re-enables caching

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
     @teams = if params[:team_name].nil?
       Team.all_including_runner_ups
     else
-      Team.where(name: params[:team_name]).includes(users: { current_period_fab: [:notes, :forward, :backward] }) << Team.runner_ups
+      Team.where(name: params[:team_name]).includes(users: { current_period_fab: [:forward, :backward] }) << Team.runner_ups
     end
 
     # This array will grow as the views iterate over users and check for

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,7 +5,7 @@ class Team < ActiveRecord::Base
 
   def self.all_including_runner_ups(eager_load = true)
     teams = if eager_load
-      self.all.includes(users: { current_period_fab: [:notes, :forward, :backward] })
+      self.all.includes(users: { current_period_fab: [:forward, :backward] })
     else
       self.all
     end

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,6 +1,6 @@
 <% @fab = user.current_period_fab || user.build_upcoming_fab %>
 
-<% cache([@fab.updated_at, @fab_editable, adminy?]) do %>
+<% cache([@fab.user.id, @fab.updated_at, @fab_editable, adminy?]) do %>
 
   <% fab_reference = "#{@fab.period.to_json}" %>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.


### PR DESCRIPTION
Per #71 
Also, `one-less query on /users` improves page load time by not preloading the notes for the users which are only needed if there are some fragment cache misses.  