### PR TITLE
Changes to the User onboarding API

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,10 +3,8 @@ class Api::V1::UsersController < Api::ApplicationController
 
   # POST /api/v1/users
   def create
-    @user = User.new(secure_params.merge(
-      password: User.generate_password,
-      email: email
-    ))
+    @user = User.where(email: email).first_or_initialize
+    @user.update(secure_params.merge(password: User.generate_password))
 
     if @user.save
       render json: { success: true, user: @user.to_json }, status: :created

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::UsersController < Api::ApplicationController
 
   private
   def secure_params
-    params.require(:user).permit(
+    params.permit(
       :name, :email, :role, :title, :avatar, :team_id, :staff,
       { personal_emails: [] },
       { fabs_attributes: [:id, :gif_tag_file_name] }
@@ -36,6 +36,6 @@ class Api::V1::UsersController < Api::ApplicationController
   end
 
   def email
-    secure_params[:email] || "#{params[:user][:username]}@eff.org"
+    secure_params[:email] || "#{params[:username]}@eff.org"
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,10 @@ class Api::V1::UsersController < Api::ApplicationController
   # POST /api/v1/users
   def create
     @user = User.where(email: email).first_or_initialize
-    @user.update(secure_params.merge(password: User.generate_password))
+    @user.update(secure_params.merge(
+      password: User.generate_password,
+      personal_emails: @user.personal_emails.concat(secure_params[:personal_emails])
+    ))
 
     if @user.save
       render json: { success: true, user: @user.to_json }, status: :created

--- a/doc/api/index.json
+++ b/doc/api/index.json
@@ -12,15 +12,15 @@
           "method": "post"
         },
         {
-          "description": "Onboard a bare-bones user",
-          "link": "onboarding_new_employees/onboard_a_bare-bones_user.json",
+          "description": "Onboard a user",
+          "link": "onboarding_new_employees/onboard_a_user.json",
           "groups": "all",
           "route": "api/v1/users",
           "method": "post"
         },
         {
-          "description": "Onboard a user with extra info",
-          "link": "onboarding_new_employees/onboard_a_user_with_extra_info.json",
+          "description": "Update a user who already exists in the database",
+          "link": "onboarding_new_employees/update_a_user_who_already_exists_in_the_database.json",
           "groups": "all",
           "route": "api/v1/users",
           "method": "post"
@@ -39,8 +39,8 @@
           "method": "delete"
         },
         {
-          "description": "With authentication, succeeds",
-          "link": "offboarding_previous_employees/with_authentication,_succeeds.json",
+          "description": "Removes a user from the database",
+          "link": "offboarding_previous_employees/removes_a_user_from_the_database.json",
           "groups": "all",
           "route": "/api/v1/users",
           "method": "delete"

--- a/doc/api/offboarding_previous_employees/removes_a_user_from_the_database.json
+++ b/doc/api/offboarding_previous_employees/removes_a_user_from_the_database.json
@@ -3,18 +3,18 @@
   "resource_explanation": null,
   "http_method": "DELETE",
   "route": "/api/v1/users",
-  "description": "With authentication, succeeds",
-  "explanation": null,
+  "description": "Removes a user from the database",
+  "explanation": "If an Authorization header containing a valid admin's API\n          token is present, the specified user will be removed from the app.\n          Either username or email must be present to identify the user.",
   "parameters": [
-    {
-      "scope": "user",
-      "name": "email",
-      "description": "The user's EFF email.  Either email or username must be present."
-    },
     {
       "scope": "user",
       "name": "username",
       "description": "The EFF-wide username; the part before '@eff.org' in their email"
+    },
+    {
+      "scope": "user",
+      "name": "email",
+      "description": "The user's EFF email"
     }
   ],
   "response_fields": [
@@ -24,12 +24,9 @@
     {
       "request_method": "DELETE",
       "request_path": "/api/v1/users",
-      "request_body": "user[username]=faker%3A%3Ainternet.user_name",
+      "request_body": "username=leopoldo_reilly",
       "request_headers": {
-        "Authorization": "b1e1458ba1a9ff4fc92109e7278cdff9",
-        "Host": "example.org",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": ""
+        "Authorization": "5d0ed576544ff64c68d317048a491d9a"
       },
       "request_query_parameters": {
       },
@@ -44,8 +41,8 @@
         "Content-Type": "application/json; charset=utf-8",
         "ETag": "W/\"7363e85fe9edee6f053a4b319588c086\"",
         "Cache-Control": "max-age=0, private, must-revalidate",
-        "X-Request-Id": "f340d7cb-6661-4b52-b4cb-e5ef8f8de677",
-        "X-Runtime": "0.006459",
+        "X-Request-Id": "e97659f3-d228-4e23-92d6-fd6e38872129",
+        "X-Runtime": "0.010421",
         "Content-Length": "16"
       },
       "response_content_type": "application/json; charset=utf-8",

--- a/doc/api/offboarding_previous_employees/without_authentication,_fails.json
+++ b/doc/api/offboarding_previous_employees/without_authentication,_fails.json
@@ -4,13 +4,8 @@
   "http_method": "DELETE",
   "route": "/api/v1/users",
   "description": "Without authentication, fails",
-  "explanation": null,
+  "explanation": "If the Authorization header is missing, or does not correspond\n        to an admin's API token, the request will fail.",
   "parameters": [
-    {
-      "scope": "user",
-      "name": "email",
-      "description": "The user's EFF email.  Either email or username must be present."
-    },
     {
       "scope": "user",
       "name": "username",
@@ -24,11 +19,8 @@
     {
       "request_method": "DELETE",
       "request_path": "/api/v1/users",
-      "request_body": "user[username]=faker%3A%3Ainternet.user_name",
+      "request_body": "username=modesto.turner",
       "request_headers": {
-        "Host": "example.org",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": ""
       },
       "request_query_parameters": {
       },

--- a/doc/api/onboarding_new_employees/onboard_a_user.json
+++ b/doc/api/onboarding_new_employees/onboard_a_user.json
@@ -3,41 +3,34 @@
   "resource_explanation": null,
   "http_method": "POST",
   "route": "api/v1/users",
-  "description": "Onboard a bare-bones user",
-  "explanation": null,
+  "description": "Onboard a user",
+  "explanation": "Authentication requires sending an 'Authorization' header\n          with an admin user's API token.  Admins can create and view an API\n          token by visiting a user's profile.\n          A username or email must be present; all other info is optional.",
   "parameters": [
     {
-      "scope": "user",
       "name": "username",
       "description": "The EFF-wide username. The part before '@' in their email"
     },
     {
-      "scope": "user",
       "name": "email",
       "description": "Their EFF email. Either email or username must be present."
     },
     {
-      "scope": "user",
       "name": "personal_emails",
       "description": "Any extra email addresses they use"
     },
     {
-      "scope": "user",
       "name": "staff",
       "description": "Should they get a FAB? Defaults to true."
     },
     {
-      "scope": "user",
       "name": "name",
       "description": "Their actual human name"
     },
     {
-      "scope": "user",
       "name": "role",
       "description": "user, admin_user_mode or admin. Defaults to user."
     },
     {
-      "scope": "user",
       "name": "title",
       "description": "What does this person do at EFF?"
     }
@@ -49,30 +42,27 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/users",
-      "request_body": "user[name]=Test+User&user[username]=chaya.gislason",
+      "request_body": "name=Test+User&username=rachael.jenkins&personal_emails[]=miracle_conn%40hand.info&personal_emails[]=aaron_gaylord%40grant.info&staff=false&role=admin&title=Pizzamancer",
       "request_headers": {
         "Accept": "application/json",
-        "Authorization": "b41fc04ca1d25184e2e004eccbf2a85d",
-        "Host": "example.org",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": ""
+        "Authorization": "592a135554253c78e31aca4fce548d16"
       },
       "request_query_parameters": {
       },
       "request_content_type": "application/x-www-form-urlencoded",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"success\": true,\n  \"user\": \"{\\\"id\\\":2,\\\"email\\\":\\\"chaya.gislason@eff.org\\\",\\\"created_at\\\":\\\"2018-03-20T12:26:12.640-07:00\\\",\\\"updated_at\\\":\\\"2018-03-20T12:26:12.640-07:00\\\",\\\"name\\\":\\\"Test User\\\",\\\"role\\\":\\\"user\\\",\\\"team_id\\\":null,\\\"title\\\":null,\\\"avatar_file_name\\\":null,\\\"avatar_content_type\\\":null,\\\"avatar_file_size\\\":null,\\\"avatar_updated_at\\\":null,\\\"personal_emails\\\":[],\\\"staff\\\":true}\"\n}",
+      "response_body": "{\n  \"success\": true,\n  \"user\": \"{\\\"id\\\":2,\\\"email\\\":\\\"rachael.jenkins@eff.org\\\",\\\"created_at\\\":\\\"2018-04-13T17:16:21.819-07:00\\\",\\\"updated_at\\\":\\\"2018-04-13T17:16:21.819-07:00\\\",\\\"name\\\":\\\"Test User\\\",\\\"role\\\":\\\"admin\\\",\\\"team_id\\\":null,\\\"title\\\":\\\"Pizzamancer\\\",\\\"avatar_file_name\\\":null,\\\"avatar_content_type\\\":null,\\\"avatar_file_size\\\":null,\\\"avatar_updated_at\\\":null,\\\"personal_emails\\\":[\\\"miracle_conn@hand.info\\\",\\\"aaron_gaylord@grant.info\\\"],\\\"staff\\\":false}\"\n}",
       "response_headers": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"8e27da2c75449fbcc79c513092968a7c\"",
+        "ETag": "W/\"4e1f8ae9fa5138099eec09a4862ec491\"",
         "Cache-Control": "max-age=0, private, must-revalidate",
-        "X-Request-Id": "9cc3c31e-5bf1-4764-a4d7-dc332b646aed",
-        "X-Runtime": "0.014604",
-        "Content-Length": "390"
+        "X-Request-Id": "ee83fd2d-129a-4ca6-9e9a-24a010f2e370",
+        "X-Runtime": "0.031211",
+        "Content-Length": "459"
       },
       "response_content_type": "application/json; charset=utf-8",
       "curl": null

--- a/doc/api/onboarding_new_employees/update_a_user_who_already_exists_in_the_database.json
+++ b/doc/api/onboarding_new_employees/update_a_user_who_already_exists_in_the_database.json
@@ -3,41 +3,34 @@
   "resource_explanation": null,
   "http_method": "POST",
   "route": "api/v1/users",
-  "description": "Onboard a user with extra info",
-  "explanation": null,
+  "description": "Update a user who already exists in the database",
+  "explanation": "If the username matches an existing user,\n            that user will be updated.",
   "parameters": [
     {
-      "scope": "user",
       "name": "username",
       "description": "The EFF-wide username. The part before '@' in their email"
     },
     {
-      "scope": "user",
       "name": "email",
       "description": "Their EFF email. Either email or username must be present."
     },
     {
-      "scope": "user",
       "name": "personal_emails",
       "description": "Any extra email addresses they use"
     },
     {
-      "scope": "user",
       "name": "staff",
       "description": "Should they get a FAB? Defaults to true."
     },
     {
-      "scope": "user",
       "name": "name",
       "description": "Their actual human name"
     },
     {
-      "scope": "user",
       "name": "role",
       "description": "user, admin_user_mode or admin. Defaults to user."
     },
     {
-      "scope": "user",
       "name": "title",
       "description": "What does this person do at EFF?"
     }
@@ -49,30 +42,27 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/users",
-      "request_body": "user[name]=Test+User&user[username]=sheldon.monahan&user[personal_emails][]=lukas%40hirthe.name&user[personal_emails][]=oswald.bailey%40weinathoeger.biz&user[staff]=false&user[role]=admin&user[title]=Pizzamancer",
+      "request_body": "name=Test+User&username=colleen.stracke&personal_emails[]=maximillian.pacocha%40wildermanheidenreich.info&personal_emails[]=virginie%40nikolaus.org&staff=false&role=admin&title=Pizzamancer",
       "request_headers": {
         "Accept": "application/json",
-        "Authorization": "3e7749398e55434b32c68013ff1262bb",
-        "Host": "example.org",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": ""
+        "Authorization": "c3a88a1bf035ec4d412f074999a5ab02"
       },
       "request_query_parameters": {
       },
       "request_content_type": "application/x-www-form-urlencoded",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\n  \"success\": true,\n  \"user\": \"{\\\"id\\\":2,\\\"email\\\":\\\"sheldon.monahan@eff.org\\\",\\\"created_at\\\":\\\"2018-03-20T14:13:09.389-07:00\\\",\\\"updated_at\\\":\\\"2018-03-20T14:13:09.389-07:00\\\",\\\"name\\\":\\\"Test User\\\",\\\"role\\\":\\\"admin\\\",\\\"team_id\\\":null,\\\"title\\\":\\\"Pizzamancer\\\",\\\"avatar_file_name\\\":null,\\\"avatar_content_type\\\":null,\\\"avatar_file_size\\\":null,\\\"avatar_updated_at\\\":null,\\\"personal_emails\\\":[\\\"lukas@hirthe.name\\\",\\\"oswald.bailey@weinathoeger.biz\\\"],\\\"staff\\\":false}\"\n}",
+      "response_body": "{\n  \"success\": true,\n  \"user\": \"{\\\"id\\\":2,\\\"email\\\":\\\"colleen.stracke@eff.org\\\",\\\"created_at\\\":\\\"2018-04-13T17:16:21.865-07:00\\\",\\\"updated_at\\\":\\\"2018-04-13T17:16:21.885-07:00\\\",\\\"name\\\":\\\"Test User\\\",\\\"role\\\":\\\"admin\\\",\\\"team_id\\\":1,\\\"title\\\":\\\"Pizzamancer\\\",\\\"avatar_file_name\\\":null,\\\"avatar_content_type\\\":null,\\\"avatar_file_size\\\":null,\\\"avatar_updated_at\\\":null,\\\"personal_emails\\\":[\\\"maximillian.pacocha@wildermanheidenreich.info\\\",\\\"virginie@nikolaus.org\\\"],\\\"staff\\\":false}\"\n}",
       "response_headers": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
         "Content-Type": "application/json; charset=utf-8",
-        "ETag": "W/\"f126763f2c93604d0a794265e3c7d405\"",
+        "ETag": "W/\"86474e03f7acd5063d73863b88e1160d\"",
         "Cache-Control": "max-age=0, private, must-revalidate",
-        "X-Request-Id": "1773cfbb-20c0-492e-a54a-6b61ce5bac3c",
-        "X-Runtime": "0.016235",
-        "Content-Length": "460"
+        "X-Request-Id": "45ec516a-7854-4ef7-b3ec-6ee3cdb14265",
+        "X-Runtime": "0.023532",
+        "Content-Length": "476"
       },
       "response_content_type": "application/json; charset=utf-8",
       "curl": null

--- a/doc/api/onboarding_new_employees/without_authentication,_fails.json
+++ b/doc/api/onboarding_new_employees/without_authentication,_fails.json
@@ -4,42 +4,11 @@
   "http_method": "POST",
   "route": "api/v1/users",
   "description": "Without authentication, fails",
-  "explanation": null,
+  "explanation": "If the Authorization header is missing, or does not correspond\n        to an admin's API token, the request will fail.",
   "parameters": [
     {
-      "scope": "user",
       "name": "username",
       "description": "The EFF-wide username. The part before '@' in their email"
-    },
-    {
-      "scope": "user",
-      "name": "email",
-      "description": "Their EFF email. Either email or username must be present."
-    },
-    {
-      "scope": "user",
-      "name": "personal_emails",
-      "description": "Any extra email addresses they use"
-    },
-    {
-      "scope": "user",
-      "name": "staff",
-      "description": "Should they get a FAB? Defaults to true."
-    },
-    {
-      "scope": "user",
-      "name": "name",
-      "description": "Their actual human name"
-    },
-    {
-      "scope": "user",
-      "name": "role",
-      "description": "user, admin_user_mode or admin. Defaults to user."
-    },
-    {
-      "scope": "user",
-      "name": "title",
-      "description": "What does this person do at EFF?"
     }
   ],
   "response_fields": [
@@ -49,12 +18,9 @@
     {
       "request_method": "POST",
       "request_path": "api/v1/users",
-      "request_body": "user[name]=Test+User&user[username]=joanne.quitzon",
+      "request_body": "username=alena.dickens",
       "request_headers": {
-        "Accept": "application/json",
-        "Host": "example.org",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": ""
+        "Accept": "application/json"
       },
       "request_query_parameters": {
       },

--- a/spec/acceptance/api/v1/users_spec.rb
+++ b/spec/acceptance/api/v1/users_spec.rb
@@ -66,6 +66,19 @@ resource "Onboarding New Employees" do
           expect(status).to eq(201)
         end
       end
+
+      context "when user already exists" do
+        let!(:user) { FactoryGirl.create(:user, email: "#{username}@eff.org") }
+        let(:new_name) { Faker::Name.name }
+        let(:raw_post) do
+          {  name: new_name, username: username }
+        end
+
+        example "Update users who already exist in the database" do
+          expect { do_request }.not_to change(User, :count)
+          expect(user.reload.name).to eq(new_name)
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/api/v1/users_spec.rb
+++ b/spec/acceptance/api/v1/users_spec.rb
@@ -7,19 +7,19 @@ resource "Onboarding New Employees" do
   post "api/v1/users" do
     let(:body) { JSON.parse(response_body) }
 
-    parameter :username, "The EFF-wide username. The part before '@' in their email", scope: :user
-    parameter :email, "Their EFF email. Either email or username must be present.", scope: :user
-    parameter :personal_emails, "Any extra email addresses they use", scope: :user
-    parameter :staff, "Should they get a FAB? Defaults to true.", scope: :user
-    parameter :name, "Their actual human name", scope: :user
-    parameter :role, "#{User::roles.keys.to_sentence(last_word_connector: ' or ')}. Defaults to user.", scope: :user
-    parameter :title, "What does this person do at EFF?", scope: :user
+    parameter :username, "The EFF-wide username. The part before '@' in their email"
+    parameter :email, "Their EFF email. Either email or username must be present."
+    parameter :personal_emails, "Any extra email addresses they use"
+    parameter :staff, "Should they get a FAB? Defaults to true."
+    parameter :name, "Their actual human name"
+    parameter :role, "#{User::roles.keys.to_sentence(last_word_connector: ' or ')}. Defaults to user."
+    parameter :title, "What does this person do at EFF?"
 
     let(:user) { User.last }
     let(:username) { "#{Faker::Name.first_name}.#{Faker::Name.last_name}".downcase }
     let(:extra_attrs) { {} }
     let(:raw_post) do
-      {  user: { name: "Test User", username: username }.merge(extra_attrs) }
+      {  name: "Test User", username: username }.merge(extra_attrs)
     end
 
     example "Without authentication, fails" do
@@ -77,7 +77,7 @@ resource "Offboarding previous employees" do
 
     let!(:user) { FactoryGirl.create(:user, email: "Faker::Internet.user_name@eff.org") }
     let(:username) { user.email.split('@').first }
-    let(:raw_post) { {  user: { username: username } } }
+    let(:raw_post) { { username: username } }
 
     example 'Without authentication, fails' do
       expect { do_request }.not_to change(User, :count)

--- a/spec/acceptance/api/v1/users_spec.rb
+++ b/spec/acceptance/api/v1/users_spec.rb
@@ -8,75 +8,63 @@ resource "Onboarding New Employees" do
     let(:body) { JSON.parse(response_body) }
 
     parameter :username, "The EFF-wide username. The part before '@' in their email"
-    parameter :email, "Their EFF email. Either email or username must be present."
-    parameter :personal_emails, "Any extra email addresses they use"
-    parameter :staff, "Should they get a FAB? Defaults to true."
-    parameter :name, "Their actual human name"
-    parameter :role, "#{User::roles.keys.to_sentence(last_word_connector: ' or ')}. Defaults to user."
-    parameter :title, "What does this person do at EFF?"
 
     let(:user) { User.last }
     let(:username) { "#{Faker::Name.first_name}.#{Faker::Name.last_name}".downcase }
-    let(:extra_attrs) { {} }
-    let(:raw_post) do
-      {  name: "Test User", username: username }.merge(extra_attrs)
-    end
 
-    example "Without authentication, fails" do
+    example 'Without authentication, fails' do
+      explanation "If the Authorization header is missing, or does not correspond
+        to an admin's API token, the request will fail.  Admins can generate and view
+        a user's API token through their profile."
       expect { do_request }.not_to change(User, :count)
       expect(response_body["success"]).to be_falsey
       expect(status).to eq(401)
     end
 
     context "authenticated requests" do
+      parameter :email, "Their EFF email. Either email or username must be present."
+      parameter :personal_emails, "Any extra email addresses they use"
+      parameter :staff, "Should they get a FAB? Defaults to true."
+      parameter :name, "Their actual human name"
+      parameter :role, "#{User::roles.keys.to_sentence(last_word_connector: ' or ')}. Defaults to user."
+      parameter :title, "What does this person do at EFF?"
+
       let!(:admin) { FactoryGirl.create(:user_admin, :with_api_key) }
       let(:auth) { admin.access_token }
+      let(:extra_emails) { 2.times.map { Faker::Internet.email } }
+      let(:title) { "Pizzamancer" }
+      let(:raw_post) do
+        { name: "Test User", username: username,
+          personal_emails: extra_emails,
+          staff: false,
+          role: 'admin',
+          title: title
+        }
+      end
 
       header "Authorization", :auth
 
-      example "Onboard a bare-bones user" do
+      example "Onboard a user" do
+        explanation "Authentication requires sending an 'Authorization' header
+          with an admin user's API token.  Admins can create and view an API
+          token by visiting a user's profile.
+          A username or email must be present; all other info is optional."
         expect { do_request }.to change(User, :count).by(1)
-        expect(user.email).to eq("#{username}@eff.org")
-        expect(user.staff).to be_truthy
-
+        expect(user.personal_emails).to match_array(extra_emails)
+        expect(user.staff).to be_falsey
+        expect(user.admin?).to be_truthy
+        expect(user.title).to eq(title)
         expect(status).to eq(201)
-        expect(body["success"]).to be_truthy
-        expect(body["user"]).to eq(user.to_json)
-      end
-
-      context "with extra info" do
-        let(:extra_emails) { 2.times.map { Faker::Internet.email } }
-        let(:title) { "Pizzamancer" }
-        let(:extra_attrs) do
-          {
-            personal_emails: extra_emails,
-            staff: false,
-            role: 'admin',
-            title: title
-          }
-        end
-
-        example "Onboard a user with extra info" do
-          expect { do_request }.to change(User, :count).by(1)
-          expect(user.personal_emails).to match_array(extra_emails)
-          expect(user.staff).to eq(false)
-          expect(user.admin?).to be_truthy
-          expect(user.title).to eq(title)
-
-          expect(status).to eq(201)
-        end
       end
 
       context "when user already exists" do
         let!(:user) { FactoryGirl.create(:user, email: "#{username}@eff.org") }
-        let(:new_name) { Faker::Name.name }
-        let(:raw_post) do
-          {  name: new_name, username: username }
-        end
 
-        example "Update users who already exist in the database" do
+        example "Update a user who already exists in the database" do
+          explanation "If the username matches an existing user,
+            that user will be updated."
           expect { do_request }.not_to change(User, :count)
-          expect(user.reload.name).to eq(new_name)
+          expect(user.reload.name).to eq(raw_post[:name])
         end
       end
     end
@@ -85,26 +73,33 @@ end
 
 resource "Offboarding previous employees" do
   delete "/api/v1/users" do
-    parameter :email, "The user's EFF email.  Either email or username must be present.", scope: :user
     parameter :username, "The EFF-wide username; the part before '@eff.org' in their email", scope: :user
 
-    let!(:user) { FactoryGirl.create(:user, email: "Faker::Internet.user_name@eff.org") }
-    let(:username) { user.email.split('@').first }
+    let!(:user) { FactoryGirl.create(:user, email: "#{username}@eff.org") }
+    let(:username) { Faker::Internet.user_name }
     let(:raw_post) { { username: username } }
 
     example 'Without authentication, fails' do
+      explanation "If the Authorization header is missing, or does not correspond
+        to an admin's API token, the request will fail. Admins can generate and view
+        a user's API token through their profile."
       expect { do_request }.not_to change(User, :count)
       expect(response_body["success"]).to be_falsey
       expect(status).to eq(401)
     end
 
     context "authenticated requests" do
+      parameter :email, "The user's EFF email", scope: :user
+
       let!(:admin) { FactoryGirl.create(:user_admin, :with_api_key) }
       let(:auth) { admin.access_token }
 
       header "Authorization", :auth
 
-      example 'With authentication, succeeds' do
+      example "Removes a user from the database" do
+        explanation "If an Authorization header containing a valid admin's API
+          token is present, the specified user will be removed from the app.
+          Either username or email must be present to identify the user."
         expect { do_request }.to change(User, :count).by(-1)
         expect(status).to eq(200)
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Api::V1::UsersController do
+  let(:username) { Faker::Internet.user_name }
+  let!(:admin) { FactoryGirl.create(:user_admin, :with_api_key) }
+  subject(:post_request) do
+    post :create, {
+      username: username, personal_emails: extra_emails, format: :json
+    }
+  end
+
+  before {
+    @request.headers['Authorization'] = admin.access_token
+  }
+
+  describe "POST #create" do
+    let(:extra_emails) { 2.times.map { Faker::Internet.email } }
+
+    example "records extra emails" do
+      expect { post_request }.to change(User, :count).by(1)
+      expect(User.last.personal_emails).to match_array(extra_emails)
+    end
+
+    context "when user has extra emails" do
+      let(:personal_emails) { [Faker::Internet.email] }
+      let!(:user) do
+        FactoryGirl.create(
+          :user, email: "#{username}@eff.org", personal_emails: personal_emails
+        )
+      end
+
+      it "adds the new emails" do
+        post_request
+        expect(user.reload.personal_emails).to match_array(
+          [extra_emails].concat(personal_emails).flatten
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,4 +100,5 @@ end
 RspecApiDocumentation.configure do |config|
   config.format = :json
   config.keep_source_order = true
+  config.request_headers_to_include = %w(Accept Authorization)
 end


### PR DESCRIPTION
* Send params without the user prefix
* Add API support for updating an existing user
* Improve User API docs
  * Explain authentication
  * Include info about how to generate and retrieve API tokens
  * Explain what each case is doin
  * Remove headers we don't care about
  * Only show parameters relevant to the case