### PR TITLE
Fix conflict between basic auth and API auth

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -4,7 +4,7 @@ class Api::ApplicationController < ApplicationController
   private
 
   def authenticate_from_access_token
-    api_key = ApiKey.find_by_access_token(request.headers["Authorization"])
+    api_key = ApiKey.find_by_access_token(request.headers["APIAuthorization"])
     head :unauthorized unless api_key && api_key.owner.admin?
   end
 end

--- a/doc/api/offboarding_previous_employees/removes_a_user_from_the_database.json
+++ b/doc/api/offboarding_previous_employees/removes_a_user_from_the_database.json
@@ -4,7 +4,7 @@
   "http_method": "DELETE",
   "route": "/api/v1/users",
   "description": "Removes a user from the database",
-  "explanation": "If an Authorization header containing a valid admin's API\n          token is present, the specified user will be removed from the app.\n          Either username or email must be present to identify the user.",
+  "explanation": "If basic auth in addition to an APIAuthorization header containing\n          a valid admin's API token is present, the specified user will be removed from\n          the app.  Either username or email must be present to identify the user.",
   "parameters": [
     {
       "scope": "user",
@@ -26,7 +26,7 @@
       "request_path": "/api/v1/users",
       "request_body": "username=leopoldo_reilly",
       "request_headers": {
-        "Authorization": "5d0ed576544ff64c68d317048a491d9a"
+        "Apiauthorization": "20d493e7279f41f553dbf45df409b1df"
       },
       "request_query_parameters": {
       },

--- a/doc/api/offboarding_previous_employees/without_authentication,_fails.json
+++ b/doc/api/offboarding_previous_employees/without_authentication,_fails.json
@@ -4,7 +4,7 @@
   "http_method": "DELETE",
   "route": "/api/v1/users",
   "description": "Without authentication, fails",
-  "explanation": "If the Authorization header is missing, or does not correspond\n        to an admin's API token, the request will fail.",
+  "explanation": "If the APIAuthorization header is missing, or does not correspond\n        to an admin's API token, the request will fail. Admins can generate and view\n        a user's API token through their profile.",
   "parameters": [
     {
       "scope": "user",

--- a/doc/api/onboarding_new_employees/onboard_a_user.json
+++ b/doc/api/onboarding_new_employees/onboard_a_user.json
@@ -4,7 +4,7 @@
   "http_method": "POST",
   "route": "api/v1/users",
   "description": "Onboard a user",
-  "explanation": "Authentication requires sending an 'Authorization' header\n          with an admin user's API token.  Admins can create and view an API\n          token by visiting a user's profile.\n          A username or email must be present; all other info is optional.",
+  "explanation": "Authentication requires sending an 'APIAuthorization' header\n          with an admin user's API token, in addition to the basic auth.\n          Admins can create and view an API token by visiting a user's profile.\n          A username or email must be present; all other info is optional.",
   "parameters": [
     {
       "name": "username",
@@ -45,7 +45,7 @@
       "request_body": "name=Test+User&username=rachael.jenkins&personal_emails[]=miracle_conn%40hand.info&personal_emails[]=aaron_gaylord%40grant.info&staff=false&role=admin&title=Pizzamancer",
       "request_headers": {
         "Accept": "application/json",
-        "Authorization": "592a135554253c78e31aca4fce548d16"
+        "Apiauthorization": "88de97ddeed9c4f4bc94d17a18aed73d"
       },
       "request_query_parameters": {
       },

--- a/doc/api/onboarding_new_employees/update_a_user_who_already_exists_in_the_database.json
+++ b/doc/api/onboarding_new_employees/update_a_user_who_already_exists_in_the_database.json
@@ -45,7 +45,7 @@
       "request_body": "name=Test+User&username=colleen.stracke&personal_emails[]=maximillian.pacocha%40wildermanheidenreich.info&personal_emails[]=virginie%40nikolaus.org&staff=false&role=admin&title=Pizzamancer",
       "request_headers": {
         "Accept": "application/json",
-        "Authorization": "c3a88a1bf035ec4d412f074999a5ab02"
+        "Apiauthorization": "ea028a7e0f3ef20f04ed7f2e749c3dd4"
       },
       "request_query_parameters": {
       },

--- a/doc/api/onboarding_new_employees/without_authentication,_fails.json
+++ b/doc/api/onboarding_new_employees/without_authentication,_fails.json
@@ -4,7 +4,7 @@
   "http_method": "POST",
   "route": "api/v1/users",
   "description": "Without authentication, fails",
-  "explanation": "If the Authorization header is missing, or does not correspond\n        to an admin's API token, the request will fail.",
+  "explanation": "If the APIAuthorization header is missing, or does not correspond\n        to an admin's API token, the request will fail.  Admins can generate and view\n        a user's API token through their profile.",
   "parameters": [
     {
       "name": "username",

--- a/spec/acceptance/api/v1/users_spec.rb
+++ b/spec/acceptance/api/v1/users_spec.rb
@@ -13,7 +13,7 @@ resource "Onboarding New Employees" do
     let(:username) { "#{Faker::Name.first_name}.#{Faker::Name.last_name}".downcase }
 
     example 'Without authentication, fails' do
-      explanation "If the Authorization header is missing, or does not correspond
+      explanation "If the APIAuthorization header is missing, or does not correspond
         to an admin's API token, the request will fail.  Admins can generate and view
         a user's API token through their profile."
       expect { do_request }.not_to change(User, :count)
@@ -42,12 +42,12 @@ resource "Onboarding New Employees" do
         }
       end
 
-      header "Authorization", :auth
+      header "APIAuthorization", :auth
 
       example "Onboard a user" do
-        explanation "Authentication requires sending an 'Authorization' header
-          with an admin user's API token.  Admins can create and view an API
-          token by visiting a user's profile.
+        explanation "Authentication requires sending an 'APIAuthorization' header
+          with an admin user's API token, in addition to the basic auth.
+          Admins can create and view an API token by visiting a user's profile.
           A username or email must be present; all other info is optional."
         expect { do_request }.to change(User, :count).by(1)
         expect(user.personal_emails).to match_array(extra_emails)
@@ -80,7 +80,7 @@ resource "Offboarding previous employees" do
     let(:raw_post) { { username: username } }
 
     example 'Without authentication, fails' do
-      explanation "If the Authorization header is missing, or does not correspond
+      explanation "If the APIAuthorization header is missing, or does not correspond
         to an admin's API token, the request will fail. Admins can generate and view
         a user's API token through their profile."
       expect { do_request }.not_to change(User, :count)
@@ -94,12 +94,12 @@ resource "Offboarding previous employees" do
       let!(:admin) { FactoryGirl.create(:user_admin, :with_api_key) }
       let(:auth) { admin.access_token }
 
-      header "Authorization", :auth
+      header "APIAuthorization", :auth
 
       example "Removes a user from the database" do
-        explanation "If an Authorization header containing a valid admin's API
-          token is present, the specified user will be removed from the app.
-          Either username or email must be present to identify the user."
+        explanation "If basic auth in addition to an APIAuthorization header containing
+          a valid admin's API token is present, the specified user will be removed from
+          the app.  Either username or email must be present to identify the user."
         expect { do_request }.to change(User, :count).by(-1)
         expect(status).to eq(200)
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::UsersController do
   end
 
   before {
-    @request.headers['Authorization'] = admin.access_token
+    @request.headers['APIAuthorization'] = admin.access_token
   }
 
   describe "POST #create" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,5 +100,5 @@ end
 RspecApiDocumentation.configure do |config|
   config.format = :json
   config.keep_source_order = true
-  config.request_headers_to_include = %w(Accept Authorization)
+  config.request_headers_to_include = %w(Accept Authorization APIAuthorization)
 end


### PR DESCRIPTION
Rename the API authorization header so that TechOps can pass basic auth and an admin API token in the same query.