### PR TITLE
Use .env instead of Figaro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ mail_password: ''
 MATTERMOST_TOKEN_WHERE: ""
 MATTERMOST_TOKEN_WHEREIS: ""
 
+SENTRY_DSN: ""
+
 ########################
 #     File Storage     #
 ########################

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,7 @@
+db_adapter='mysql2'
+db_encoding='utf8mb4'
+db_database='eff_fab_prod'
+db_username='eff_fab'
+db_password=''
+db_host='127.0.0.1'
+db_port=3306

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,8 @@ pickle-email-*.html
 
 # Environment files that may contain sensitive data
 .env
+.env.production
 .powenv
 
 # tilde files are usually backup files from a text editor
 *~
-
-config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
+gem 'dotenv-rails'
+
 ruby '2.3.1'
 
 gem 'rails', '4.2.10'
@@ -27,7 +29,6 @@ group :development do
   gem 'spring'
 end
 gem 'devise'
-gem 'figaro'
 gem "paperclip"
 gem 'puma'
 gem 'simple_form'
@@ -50,23 +51,10 @@ end
 group :production do
   gem 'rails_12factor'
 
-  # Include database gems for the adapters found in the database
-  # configuration settings key for production
-  require 'erb'
-  require 'yaml'
-  application_file = File.join(File.dirname(__FILE__), "config/application.yml")
-  if File.exist?(application_file)
-    application_config = YAML::load(ERB.new(IO.read(application_file)).result)
-    db_adapter = application_config['production']['db_adapter']
-    if db_adapter == "mysql2"
-      gem 'mysql2'
-    elsif db_adapter == "postgresql"
-      gem 'pg'
-    else
-      warn("No adapter found in config/application.yml, please configure it first")
-    end
-  else
-    warn("Please configure your config/application.yml first")
+  if ENV['db_adapter'] == "postgresql"
+    gem 'pg'
+  elsif ENV['db_adapter']
+    gem ENV['db_adapter']
   end
 end
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    dotenv (2.2.2)
+    dotenv-rails (2.2.2)
+      dotenv (= 2.2.2)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -96,8 +100,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.21)
-    figaro (1.1.1)
-      thor (~> 0.14)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.9.5)
@@ -294,10 +296,10 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise
+  dotenv-rails
   execjs
   factory_girl_rails
   faker
-  figaro
   jbuilder (~> 2.0)
   jquery-rails
   jquery-tablesorter

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,20 +29,6 @@ module EffFab
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
 
-    # allow Mattermost slash commands
-    config.mattermost_settings = {
-      domain: ENV['MATTERMOST_DOMAIN'],
-      where_token: ENV['MATTERMOST_TOKEN_WHERE'],
-      whereis_token: ENV['MATTERMOST_TOKEN_WHEREIS']
-    }
-    #TODO: remove this when we move to dotenv
-    config.imap_settings = {
-      port: ENV['INCOMING_MAIL_PORT'],
-      server: ENV['INCOMING_MAIL_SERVER'],
-      username: ENV['WHEREBOT_USER_NAME'],
-      password: ENV['WHEREBOT_PASSWORD']
-    }
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
For consistency and predictability with our other apps, as well as to  remove the infrequently-maintained and irritatingly-configured Figaro.

Closes #97

I'm not confident the production env variables will be loaded correctly, but what the h*ck is the point of having a different db adapter on production?  Someone probably thought it made sense.  Anyway, check that the db loads properly after deploy.