### PR TITLE
Remove Mattermost IP check

### DIFF
--- a/app/controllers/api/v1/mattermost_controller.rb
+++ b/app/controllers/api/v1/mattermost_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::MattermostController < Api::ApplicationController
   require_dependency 'commands'
 
   skip_before_action :login_by_basic_auth
-  before_action :authenticate_mattermost
 
   def where
     render json: Commands::Where.new(command_params).response
@@ -13,10 +12,6 @@ class Api::V1::MattermostController < Api::ApplicationController
   end
 
   private
-
-  def authenticate_mattermost
-    head :unauthorized unless ENV['MATTERMOST_IPS'].split.include?(request.remote_ip)
-  end
 
   def command_params
     params.permit(:user_name, :text, :token)

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -36,7 +36,6 @@ mail_password: ''
 ########################
 MATTERMOST_TOKEN_WHERE: ""
 MATTERMOST_TOKEN_WHEREIS: ""
-MATTERMOST_IPS: ""
 
 ########################
 #     File Storage     #

--- a/spec/controllers/api/v1/mattermost_controller_spec.rb
+++ b/spec/controllers/api/v1/mattermost_controller_spec.rb
@@ -6,7 +6,6 @@ describe Api::V1::MattermostController do
   let(:username) { user.email.split("@").first }
   let(:text) { Faker::ChuckNorris.fact.parameterize('+') }
   let(:auth_token) { "let_me_in_ok" }
-  let(:mattermost_ip) { '127.238.349' }
   let(:slash_params) do
     # https://docs.mattermost.com/developer/slash-commands.html
     { command: command, text: text, token: auth_token, user_name: username, format: :json }
@@ -15,16 +14,6 @@ describe Api::V1::MattermostController do
   before do
     ENV['MATTERMOST_TOKEN_WHERE'] = auth_token
     ENV['MATTERMOST_TOKEN_WHEREIS'] = auth_token
-    ENV['MATTERMOST_IPS'] = "#{mattermost_ip} some.other.ip"
-    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip)
-      .and_return(mattermost_ip)
-  end
-
-  shared_examples "fails" do
-    it "fails" do
-      create
-      expect(response.status).to eq(401)
-    end
   end
 
   shared_examples "mattermost command" do
@@ -37,15 +26,6 @@ describe Api::V1::MattermostController do
       # Mattermost needs these two keys to render a response
       expect(JSON.parse(response.body).keys).to include("response_type")
       expect(JSON.parse(response.body).keys).to include("text")
-    end
-
-    context "from a non-mattermost IP" do
-      before do
-        allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip)
-          .and_return("1.2.3.4")
-      end
-
-      include_examples "fails"
     end
   end
 


### PR DESCRIPTION
The way the loadbalancer and firewalls are set up, it doesn't make sense to check an IP.