### PR TITLE
Remove email lookup from user onboarding

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -37,6 +37,6 @@ class Api::V1::UsersController < Api::ApplicationController
   end
 
   def email
-    secure_params[:email] || "#{params[:username]}@eff.org"
+    "#{params[:username]}@eff.org"
   end
 end


### PR DESCRIPTION
Rocket says it's better just to look up by username, so the API can update emails.