### PR TITLE
Several Mattermost fixes

### DIFF
--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -3,13 +3,10 @@ class Commands
   RESPONSE_TYPE =  { private: "ephemeral" }
 
   def initialize(args)
+    @body = args[:text]
     @username = args[:user_name]
     @token = args[:token]
     @command = args[:command]
-  end
-
-  def target_user
-    @user ||= User.find_by(email: "#{@username}@eff.org")
   end
 
   def response
@@ -56,12 +53,15 @@ class Commands::WhereIs < Commands
       "#{target_user.name} hasn't set a where recently."
     end
   end
+
+  def target_user
+    @user ||= User.find_by(email: "#{@body.split(' ').first}@eff.org")
+  end
 end
 
 class Commands::Where < Commands
-  def initialize(args)
-    @body = args[:text]
-    super
+  def target_user
+    @user ||= User.find_by(email: "#{@username}@eff.org")
   end
 
   def command

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -46,7 +46,10 @@ class Commands::WhereIs < Commands
   end
 
   def message
-    if target_user.last_whereabouts.present?
+    if target_user.nil?
+      "I couldn't find \"#{target_username}\". Is that the right username?\n
+       A person's username is the part before \"@\" in their eff email."
+    elsif target_user.last_whereabouts.present?
       time = target_user.last_whereabouts.sent_at
       "At #{time.strftime('%-l:%M%P')} on #{time.strftime('%m/%d/%y')}, #{target_user.name} sent \"#{target_user.last_whereabouts.body}\""
     else
@@ -55,7 +58,13 @@ class Commands::WhereIs < Commands
   end
 
   def target_user
-    @user ||= User.find_by(email: "#{@body.split(' ').first}@eff.org")
+    @user ||= User.find_by(email: "#{target_username}@eff.org")
+  end
+
+  private
+
+  def target_username
+    @body.split(' ').first
   end
 end
 
@@ -69,7 +78,7 @@ class Commands::Where < Commands
   end
 
   def message
-    if create_where
+    if target_user.present? && create_where
       "Your whereabouts are now set to \"#{@body}\"."
     else
       "I couldn't save your message. Better send it it to where@eff.org :sweat_smile:"

--- a/spec/controllers/api/v1/mattermost_controller_spec.rb
+++ b/spec/controllers/api/v1/mattermost_controller_spec.rb
@@ -4,7 +4,6 @@ require 'commands'
 describe Api::V1::MattermostController do
   let!(:user) { FactoryGirl.create(:user, email: "cool.kittens@eff.org") }
   let(:username) { user.email.split("@").first }
-  let(:text) { Faker::ChuckNorris.fact.parameterize('+') }
   let(:auth_token) { "let_me_in_ok" }
   let(:slash_params) do
     # https://docs.mattermost.com/developer/slash-commands.html
@@ -30,6 +29,7 @@ describe Api::V1::MattermostController do
   end
 
   describe "#where" do
+    let(:text) { Faker::ChuckNorris.fact.parameterize('+') }
     let(:command) { Commands::Where }
     subject(:create) { post :where, slash_params }
 
@@ -37,6 +37,7 @@ describe Api::V1::MattermostController do
   end
 
   describe "#where_is" do
+    let(:text) { user.username }
     let(:command) { Commands::WhereIs }
     subject(:create) { post :where_is, slash_params }
 

--- a/spec/lib/commands/where_is_spec.rb
+++ b/spec/lib/commands/where_is_spec.rb
@@ -33,15 +33,16 @@ RSpec.describe Commands::WhereIs do
 
       it "responds with the most recent where" do
         time = user.last_whereabouts.sent_at
-        expect(response_body[:text]).to include(time.strftime('%-l:%M%P'))
-        expect(response_body[:text]).to include(time.strftime('%m/%d/%y'))
-        expect(response_body[:text]).to include(user.name)
-        expect(response_body[:text]).to include(user.last_whereabouts.body)
+        attachment = response_body[:attachments].first
+        expect(attachment[:title]).to include(time.strftime('%-l:%M%P'))
+        expect(attachment[:title]).to include(time.strftime('%m/%d/%y'))
+        expect(attachment[:author_name]).to include(user.name)
+        expect(attachment[:text]).to include(user.last_whereabouts.body)
       end
 
-      it "responds with the necessary keys" do
+      it "responds with a pretty attachment" do
         expect(response_body.keys).to match_array(
-          [:response_type, :text, :username]
+          [:response_type, :attachments, :username]
         )
       end
 

--- a/spec/lib/commands/where_is_spec.rb
+++ b/spec/lib/commands/where_is_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe Commands::WhereIs do
       it "sets the username" do
         expect(response_body[:username]).to eq("Wherebot")
       end
+
+      context "when user is not found" do
+        subject(:response_body) do
+          described_class.new(
+            {
+              user_name: asker.username, command: "where_is", text: "nope"
+            }.merge(extra_args)
+          ).response
+        end
+
+        it "returns a friendly message" do
+          expect(response_body[:text]).to match(/I couldn't find "nope"/)
+        end
+      end
     end
   end
 end

--- a/spec/lib/commands/where_is_spec.rb
+++ b/spec/lib/commands/where_is_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe Commands::WhereIs do
           expect(response_body[:text]).to match(/I couldn't find "nope"/)
         end
       end
+
+      context "with no wheres" do
+        before { WhereMessage.destroy_all }
+
+        it "responds with a friendly message" do
+          expect(response_body[:text]).to match(/#{user.name} hasn't set a where/)
+        end
+
+        it "responds with the necessary keys" do
+          expect(response_body.keys).to match_array(
+            [:response_type, :text, :username]
+          )
+        end
+      end
     end
   end
 end

--- a/spec/lib/commands/where_is_spec.rb
+++ b/spec/lib/commands/where_is_spec.rb
@@ -1,17 +1,18 @@
 require 'commands'
 
 RSpec.describe Commands::WhereIs do
-  let(:user) { FactoryGirl.create(:user, email: "cool.kitten@eff.org") }
+  let(:asker) { FactoryGirl.create(:user) }
+  let(:user) { FactoryGirl.create(:user) }
   let(:extra_args) { {} }
-  let(:args) { { user_name: user.username, command: 'where_is' }.merge(extra_args) }
-  let(:command) { described_class.new(args) }
-
-  before do
-    ENV['MATTERMOST_TOKEN_WHEREIS'] = 'valid_token'
+  let(:args) do
+    { user_name: asker.username, command: 'where_is', text: user.username }
+      .merge(extra_args)
   end
 
+  before { ENV['MATTERMOST_TOKEN_WHEREIS'] = 'valid_token' }
+
   describe ".response" do
-    subject(:response_body) { command.response }
+    subject(:response_body) { described_class.new(args).response }
 
     before do
       2.times do

--- a/spec/lib/commands/where_spec.rb
+++ b/spec/lib/commands/where_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Commands::Where do
         expect(response_body[:username]).to eq("Wherebot")
       end
 
+      context "when user is not found" do
+        subject(:response_body) do
+          described_class.new(
+            { user_name: "nope", command: "where_is" }.merge(extra_args)
+          ).response
+        end
+
+        it "returns a friendly message" do
+          expect(response_body[:text]).to match(/I couldn't save your message/)
+        end
+      end
+
       context "failure" do
         before { allow_any_instance_of(WhereMessage).to receive(:save).and_return(false) }
 


### PR DESCRIPTION
/where_is: 
  * return the whereabouts of the target user, not the user sending the command
  * fill in some test coverage around what happens when the target user has no wheres
  * format the response as an attachment:
<img width="887" alt="screen shot 2018-04-20 at 6 25 55 pm" src="https://user-images.githubusercontent.com/1065956/39079059-505070c0-44c8-11e8-80a8-449c9f3431a8.png">


both commands: 
  * when target user is not found, return a friendly message
    https://sentry.eff.org/eff/fabefforg/issues/50116/
