### PR TITLE
Rename mattermost command to create a new where message

### DIFF
--- a/app/controllers/api/v1/mattermost_controller.rb
+++ b/app/controllers/api/v1/mattermost_controller.rb
@@ -3,8 +3,8 @@ class Api::V1::MattermostController < Api::ApplicationController
 
   skip_before_action :login_by_basic_auth
 
-  def where
-    render json: Commands::Where.new(command_params).response
+  def set_my_where
+    render json: Commands::SetMyWhere.new(command_params).response
   end
 
   def where_is

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
       end
       resources :mattermost, only: [] do
         collection do
-          post :where
+          post :set_my_where
           post :where_is
         end
       end

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -81,7 +81,7 @@ class Commands::WhereIs < Commands
   end
 end
 
-class Commands::Where < Commands
+class Commands::SetMyWhere < Commands
   def target_user
     @user ||= User.find_by(email: "#{@username}@eff.org")
   end

--- a/spec/controllers/api/v1/mattermost_controller_spec.rb
+++ b/spec/controllers/api/v1/mattermost_controller_spec.rb
@@ -28,10 +28,10 @@ describe Api::V1::MattermostController do
     end
   end
 
-  describe "#where" do
+  describe "#set_my_where" do
     let(:text) { Faker::ChuckNorris.fact.parameterize('+') }
-    let(:command) { Commands::Where }
-    subject(:create) { post :where, slash_params }
+    let(:command) { Commands::SetMyWhere }
+    subject(:create) { post :set_my_where, slash_params }
 
     include_examples "mattermost command"
   end

--- a/spec/lib/commands/set_my_where_spec.rb
+++ b/spec/lib/commands/set_my_where_spec.rb
@@ -1,11 +1,11 @@
 require 'commands'
 
-RSpec.describe Commands::Where do
+RSpec.describe Commands::SetMyWhere do
   let(:user) { FactoryGirl.create(:user, email: "cool.kitten@eff.org") }
   let(:body) { "WFC AUW EOM" }
   let(:extra_args) { {} }
   let(:args) do
-    { user_name: user.username, text: body, command: 'where' }.merge(extra_args)
+    { user_name: user.username, text: body, command: 'set_my_where' }.merge(extra_args)
   end
   let(:command) { described_class.new(args) }
 


### PR DESCRIPTION
The Wherebot planning team talked about it and decided that this would be more intuitive for people.