### PR TITLE
Fix tablesorter with special characters

### DIFF
--- a/app/assets/javascripts/app/init.js
+++ b/app/assets/javascripts/app/init.js
@@ -43,7 +43,8 @@ function instantiateOrResetParalax() {
 function sortTables() {
   $(".tablesorter").tablesorter({
     theme: 'materialize',
-    widgets: ['filter']
+    widgets: ['filter'],
+    sortLocaleCompare: true
   });
 };
 


### PR DESCRIPTION
https://redmine.eff.org/issues/17229
If you search for "Andres", Andrés did not come up.  Fortunately Tablesorter has thought of this already.