### PR TITLE
Fix the weird formatting on /where_is failure

### DIFF
--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -50,7 +50,7 @@ class Commands::WhereIs < Commands
   def response_body
     if target_user.nil?
       {
-        text: "I couldn't find \"#{target_username}\". Is that the right username?  A person's username is the part before \"@\" in their eff email."
+        text: "I couldn't find \"#{target_username}\". Is that the right username?\n  A person's username is the part before \"@\" in their eff email."
       }
     elsif target_user.last_whereabouts.present?
       time = target_user.last_whereabouts.sent_at

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -50,8 +50,7 @@ class Commands::WhereIs < Commands
   def response_body
     if target_user.nil?
       {
-        text: "I couldn't find \"#{target_username}\". Is that the right username?\n
-               A person's username is the part before \"@\" in their eff email."
+        text: "I couldn't find \"#{target_username}\". Is that the right username?  A person's username is the part before \"@\" in their eff email."
       }
     elsif target_user.last_whereabouts.present?
       time = target_user.last_whereabouts.sent_at


### PR DESCRIPTION
I guess Mattermost reads "\n" as "start a preformatted block".
![screen shot 2018-04-26 at 10 55 32 am](https://user-images.githubusercontent.com/1065956/39323035-60363750-4940-11e8-8401-9b2f386a1d57.png)
