### PR TITLE
Only include staff in FAB reports.

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -62,7 +62,7 @@ class ToolsController < ApplicationController
 
   def populate_this_weeks_fabs
     new_records_count = 0
-    User.all.each do |u|
+    User.staff.each do |u|
       f = u.fabs.find_or_build_this_periods_fab
       if f.new_record?
         f.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,8 @@ class User < ActiveRecord::Base
 
   before_save { |t| t.email = t.email.downcase }
 
+  scope :staff, -> { where(staff: true) }
+
   # this function returns the FAB due for the upcoming week, or builds it if
   # no such fab already exists
   def upcoming_fab

--- a/lib/mailers.rb
+++ b/lib/mailers.rb
@@ -1,13 +1,13 @@
 # use this script from controllers or rake tasks :)
 
 def turbo_remind
-  User.all.each do |user|
+  User.staff.each do |user|
     FabMailer.remind(user).deliver_now if user.upcoming_fab_still_missing?
   end
 end
 
 def turbo_last_minute_remind
-  User.all.each do |user|
+  User.staff.each do |user|
     if user.upcoming_fab_still_missing? or user.upcoming_fab_still_missing_for_team_mate?
       FabMailer.last_minute_remind(user).deliver_now
     end
@@ -15,7 +15,7 @@ def turbo_last_minute_remind
 end
 
 def turbo_report_on_aftermath
-  User.all.each do |user|
+  User.staff.each do |user|
     FabMailer.report_on_aftermath(user).deliver_now if user.previous_fab_still_missing?
   end
 end

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe ToolsController, type: :controller do
+  describe 'POST #populate_this_weeks_fabs' do
+    let(:admin) { FactoryGirl.create(:user_admin) }
+    let!(:staff) { FactoryGirl.create(:user) }
+    let!(:intern) { FactoryGirl.create(:user, staff: false) }
+    subject(:action) { post :populate_this_weeks_fabs }
+
+    before { sign_in admin }
+
+    it "creates a FAB for each staff member" do
+      expect { action }.to change(staff.fabs, :count)
+    end
+
+    it "ignores non-staff users" do
+      expect { action }.not_to change(intern.fabs, :count)
+    end
+
+    it 'redirects to admin' do
+      action
+      expect(response).to redirect_to admin_path
+    end
+  end
+end

--- a/spec/lib/mailer_spec.rb
+++ b/spec/lib/mailer_spec.rb
@@ -1,0 +1,44 @@
+require "mailers"
+
+RSpec.describe "mailer tasks" do
+  let!(:staff) { FactoryGirl.create(:user) }
+  let!(:intern) { FactoryGirl.create(:user, staff: false) }
+
+  describe "turbo_remind" do
+    before do
+      allow(FabMailer).to receive(:remind).and_return(double(deliver_now: true))
+    end
+
+    it "includes staff members" do
+      expect(FabMailer).to receive(:remind).with(staff)
+      expect(FabMailer).not_to receive(:remind).with(intern)
+      turbo_remind
+    end
+  end
+
+  describe "turbo_last_minute_remind" do
+    before do
+      allow(FabMailer).to receive(:last_minute_remind).and_return(double(deliver_now: true))
+    end
+
+    it "includes staff members" do
+      expect(FabMailer).to receive(:last_minute_remind).with(staff)
+      expect(FabMailer).not_to receive(:last_minute_remind).with(intern)
+
+      turbo_last_minute_remind
+    end
+  end
+
+  describe "turbo_report_on_aftermath" do
+    before do
+      allow(FabMailer).to receive(:report_on_aftermath).and_return(double(deliver_now: true))
+    end
+
+    it "includes staff members" do
+      expect(FabMailer).to receive(:report_on_aftermath).with(staff)
+      expect(FabMailer).not_to receive(:report_on_aftermath).with(intern)
+
+      turbo_report_on_aftermath
+    end
+  end
+end


### PR DESCRIPTION
TechOps requested a "staff" flag to differentiate between employees who should receive staff-only prompts and permissions, like FABs, and those who shouldn't, like interns and contractors.  When I added the flag, i forgot to make it do anything >_<