### PR TITLE
Don't overwrite info when updating or viewing users through the API

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,11 +4,11 @@ class Api::V1::UsersController < Api::ApplicationController
   # POST /api/v1/users
   def create
     # In practice, TechOps is using this endpoint to create new users,
-    # as well as update and look at existing users.
+    # as well as update existing users.
     # It's a little unconventional, but that's what's happening.
     @user = User.where(email: email).first_or_initialize
 
-    if create_update_or_view
+    if @user.update(new_params)
       render json: { success: true, user: @user.to_json }, status: :created
     else
       render json: { success: false, errors: @user.errors }, status: :unprocessable_entity
@@ -44,16 +44,11 @@ class Api::V1::UsersController < Api::ApplicationController
   end
 
   def new_params
-    new_params = secure_params
-    new_params.merge(password: User.generate_password) if @user.new_record?
-    new_params.merge(personal_emails: personal_emails) if personal_emails.any?
-  end
-
-  def create_update_or_view
-    if new_params || @user.new_record?
-      @user.save(new_params)
-    else
-      @user
+    new_params ||= begin
+      new_attrs = secure_params
+      new_attrs.merge!(password: User.generate_password) if @user.new_record?
+      new_attrs.merge!(personal_emails: personal_emails) if personal_emails.any?
+      new_attrs
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::UsersController < Api::ApplicationController
 
   # POST /api/v1/users
   def create
-    # In practice, TechOps is using this endpoint to create new users,
+    # TechOps is using this endpoint to create new users,
     # as well as update existing users.
     # It's a little unconventional, but that's what's happening.
     @user = User.where(email: email).first_or_initialize
 
-    if @user.update(new_params)
+    if @user.update(secure_params)
       render json: { success: true, user: @user.to_json }, status: :created
     else
       render json: { success: false, errors: @user.errors }, status: :unprocessable_entity
@@ -29,10 +29,14 @@ class Api::V1::UsersController < Api::ApplicationController
   private
 
   def secure_params
-    params.permit(
+    attrs = params.permit(
       :name, :email, :role, :title, :avatar, :team_id, :staff,
       { fabs_attributes: [:id, :gif_tag_file_name] }
-    )
+    ).tap do |whitelisted|
+      # allow TechOps to send emails as strings or arrays
+      whitelisted[:personal_emails] = params[:personal_emails] if params[:personal_emails]
+    end
+    attrs
   end
 
   def email
@@ -41,14 +45,5 @@ class Api::V1::UsersController < Api::ApplicationController
 
   def personal_emails
     params.fetch(:personal_emails, '').split(',').flatten.compact.uniq
-  end
-
-  def new_params
-    new_params ||= begin
-      new_attrs = secure_params
-      new_attrs.merge!(password: User.generate_password) if @user.new_record?
-      new_attrs.merge!(personal_emails: personal_emails) if personal_emails.any?
-      new_attrs
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ActiveRecord::Base
 
   delegate :access_token, to: :api_key, allow_nil: true
 
+  before_validation :initialize_password
   before_save { |t| t.email = t.email.downcase }
 
   scope :staff, -> { where(staff: true) }
@@ -111,5 +112,15 @@ class User < ActiveRecord::Base
 
   def username
     email.split("@").first
+  end
+
+  def personal_emails=(emails)
+    write_attribute :personal_emails, (emails || []).split(',').flatten.compact.uniq
+  end
+
+  private
+
+  def initialize_password
+    self.password = User.generate_password if new_record? && self.password.blank?
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -16,6 +16,17 @@ describe Api::V1::UsersController do
       expect(User.last.username).to eq(username)
     end
 
+    context "with invalid info" do
+      let(:response_body) { JSON.parse(response.body) }
+      before { allow_any_instance_of(User).to receive(:valid?).and_return(false) }
+
+      it "fails to create a user" do
+        expect { post_request }.to change(User, :count).by(0)
+        expect(response_body["success"]).to eq(false)
+        expect(response_body.keys).to include("errors")
+      end
+    end
+
     context "with personal emails" do
       subject(:post_request) do
         post :create, { username: username, personal_emails: extra_emails }
@@ -45,46 +56,67 @@ describe Api::V1::UsersController do
     describe "when user exists" do
       let(:user) { FactoryGirl.create(:user, staff: false) }
 
-      it 'suceeds' do
+      it "updates the user" do
         post :create, { username: user.username, staff: true }
         expect(response).to be_successful
         expect(user.reload.staff).to eq(true)
       end
 
       context "when user has personal emails" do
+        let(:personal_emails) { 2.times.map { Faker::Internet.email } }
         let(:extra_emails) { "me@coolmail.net,me@evencoolermail.net" }
         let!(:user) do
           FactoryGirl.create(
             :user,
             email: "#{username}@eff.org",
-            personal_emails: 2.times.map { Faker::Internet.email }
+            personal_emails: personal_emails
           )
         end
 
-        it "overwrites them" do
+        it "overwrites the existing emails with new emails" do
           post :create, { username: username, personal_emails: extra_emails }
 
           expect(User.last.personal_emails).to match_array(
             ["me@coolmail.net", "me@evencoolermail.net"]
           )
         end
+
+        it "retains the existing emails if no new emails are present" do
+          expect(user.reload.staff).to be_truthy
+
+          post :create, { username: username, staff: false }
+
+          expect(user.reload.personal_emails).to match_array(personal_emails)
+          expect(user.reload.staff).to be_falsey
+        end
       end
 
       context "without changes" do
-        # techOps uses this endpoint to create, update, and view users.
+        # techOps uses this endpoint to update users.
         let(:personal_emails) { ['hi@ok.com', 'yes@also.com'] }
         let!(:user) { FactoryGirl.create(:user, personal_emails: personal_emails) }
-        let(:action) { post :create, username: user.username }
+        let(:post_request) { post :create, username: user.username }
 
         it "does not update the user" do
           old_password = user.encrypted_password
-          action
+          post_request
           expect(user.reload.encrypted_password).to eq(old_password)
         end
 
         it "does not overwrite the personal emails" do
-          action
+          post_request
           expect(user.reload.personal_emails).to match_array(personal_emails)
+        end
+      end
+
+      context "with invalid info" do
+        let(:response_body) { JSON.parse(response.body) }
+        before { allow_any_instance_of(User).to receive(:valid?).and_return(false) }
+
+        it "fails to update the user" do
+          post_request
+          expect(response_body["success"]).to eq(false)
+          expect(response_body.keys).to include("errors")
         end
       end
     end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -27,32 +27,6 @@ describe Api::V1::UsersController do
       end
     end
 
-    context "with personal emails" do
-      subject(:post_request) do
-        post :create, { username: username, personal_emails: extra_emails }
-      end
-
-      context "when emails are an array" do
-        let(:extra_emails) { 2.times.map { Faker::Internet.email } }
-
-        it "records extra emails" do
-          post_request
-          expect(User.last.personal_emails).to match_array(extra_emails)
-        end
-      end
-
-      context "when emails are a string" do
-        let(:extra_emails) { "me@coolmail.net,me@evencoolermail.net" }
-
-        it "records extra emails" do
-          post_request
-          expect(User.last.personal_emails).to match_array(
-            ["me@coolmail.net", "me@evencoolermail.net"]
-          )
-        end
-      end
-    end
-
     describe "when user exists" do
       let(:user) { FactoryGirl.create(:user, staff: false) }
 
@@ -92,7 +66,6 @@ describe Api::V1::UsersController do
       end
 
       context "without changes" do
-        # techOps uses this endpoint to update users.
         let(:personal_emails) { ['hi@ok.com', 'yes@also.com'] }
         let!(:user) { FactoryGirl.create(:user, personal_emails: personal_emails) }
         let(:post_request) { post :create, username: user.username }

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -69,6 +69,24 @@ describe Api::V1::UsersController do
           )
         end
       end
+
+      context "without changes" do
+        # techOps uses this endpoint to create, update, and view users.
+        let(:personal_emails) { ['hi@ok.com', 'yes@also.com'] }
+        let!(:user) { FactoryGirl.create(:user, personal_emails: personal_emails) }
+        let(:action) { post :create, username: user.username }
+
+        it "does not update the user" do
+          old_password = user.encrypted_password
+          action
+          expect(user.reload.encrypted_password).to eq(old_password)
+        end
+
+        it "does not overwrite the personal emails" do
+          action
+          expect(user.reload.personal_emails).to match_array(personal_emails)
+        end
+      end
     end
   end
 end

--- a/spec/features/pages/sign_up_spec.rb
+++ b/spec/features/pages/sign_up_spec.rb
@@ -23,15 +23,6 @@ feature 'Sign Up', :devise do
     expect(page).to have_content 'Email is invalid'
   end
 
-  # Scenario: Visitor cannot sign up without password
-  #   Given I am not signed in
-  #   When I sign up without a password
-  #   Then I see a missing password message
-  scenario 'visitor cannot sign up without password' do
-    sign_up_with('test@example.com', '', '')
-    expect(page).to have_content "Password can't be blank"
-  end
-
   # Scenario: Visitor cannot sign up with a short password
   #   Given I am not signed in
   #   When I sign up with a short password

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,4 +104,28 @@ describe User do
     end
   end
 
+  context "parses personal emails" do
+    let(:user) { FactoryGirl.create(:user) }
+    subject(:save_user) { user.update(personal_emails: extra_emails) }
+
+    context "when emails are an array" do
+      let(:extra_emails) { 2.times.map { Faker::Internet.email } }
+
+      it "records extra emails" do
+        save_user
+        expect(user.reload.personal_emails).to match_array(extra_emails)
+      end
+    end
+
+    context "when emails are a string" do
+      let(:extra_emails) { "me@coolmail.net,me@evencoolermail.net" }
+
+      it "records extra emails" do
+        save_user
+        expect(user.reload.personal_emails).to match_array(
+          ["me@coolmail.net", "me@evencoolermail.net"]
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because I initially wrote POST /api/v1/users as a creation endpoint, the implementation assumed a user without existing data. However, it's convenient for TechOps to use that one endpoint for creation, update and view, so sometimes the user will have existing data that shouldn't be overwritten.