### PR TITLE
Log more info about wherebot failures

### DIFF
--- a/lib/wherebot.rb
+++ b/lib/wherebot.rb
@@ -86,6 +86,7 @@ class Wherebot
 
       destroy_message if wm.save!
     rescue => e
+      Raven.extra_context(email: from, subject: subject, body: body)
       Raven.captureException(e)
       false
     end

--- a/spec/lib/wherebot_spec.rb
+++ b/spec/lib/wherebot_spec.rb
@@ -145,6 +145,9 @@ RSpec.describe Wherebot do
 
         it "tells Sentry about it" do
           expect(Raven).to receive(:captureException)
+          expect(Raven).to receive(:extra_context).with(hash_including(
+            email: mail.from, subject: mail.subject
+          ))
           wherebot_message.create
         end
       end


### PR DESCRIPTION
I'm seeing a bunch of Sentry errors around not finding users.  It would be great to know what email addresses are causing those failures.