### PR TITLE
The mystery of the missing FABs

### DIFF
--- a/app/assets/stylesheets/styles/main.scss
+++ b/app/assets/stylesheets/styles/main.scss
@@ -243,11 +243,6 @@
   }
 }
 
-.fab-notes {
-  padding-bottom: 20px;
-  padding-right: 10px;
-}
-
 .nested-fields {
   text-align: center;
   @include susy-breakpoint($md) {
@@ -348,22 +343,21 @@ h3 a {
   padding-top: 2em;
   padding-bottom: 1.5em;
 
-  .fab {
-    h3 a {
-      color: #bbb !important;
-      font-size: 14px;
-      text-transform: uppercase;
-      font-family: 'Montserrat';
-      font-weight: 300;
-      letter-spacing: 0.03em;
-      margin-bottom: 1em;
-    }
-    .fab-notes {
-      font-family: 'Lato';
-      font-weight: 300;
-      letter-spacing: 0.15px;
-    }
+  h3 a {
+    color: #bbb !important;
+    font-size: 14px;
+    text-transform: uppercase;
+    font-family: 'Montserrat';
+    font-weight: 300;
+    letter-spacing: 0.03em;
+    margin-bottom: 1em;
   }
+}
+.fab-notes {
+  font-family: 'Lato';
+  font-weight: 300;
+  letter-spacing: 0.15px;
+  padding-bottom: 20px;
 }
 // unless/until fabfilter works on individual fab pages
 body#fabs-index {

--- a/app/helpers/fabs_helper.rb
+++ b/app/helpers/fabs_helper.rb
@@ -24,4 +24,11 @@ module FabsHelper
     end
   end
 
+  def backward_or_placeholders(fab)
+    backwards = fab.backward.pluck(:body)
+    return backwards if backwards.all?(&:present?)
+
+    placeholders = fab.exactly_previous_fab.forward.pluck(:body)
+    backwards.concat(placeholders).select(&:present?).compact.uniq
+  end
 end

--- a/app/helpers/fabs_helper.rb
+++ b/app/helpers/fabs_helper.rb
@@ -29,6 +29,6 @@ module FabsHelper
     return backwards if backwards.all?(&:present?)
 
     placeholders = fab.exactly_previous_fab.forward.pluck(:body)
-    backwards.concat(placeholders).select(&:present?).compact.uniq
+    backwards.concat(placeholders).select(&:present?).uniq
   end
 end

--- a/app/helpers/fabs_helper.rb
+++ b/app/helpers/fabs_helper.rb
@@ -1,10 +1,13 @@
 module FabsHelper
 
-  def display_fab_note_inputs(options)
-    form = options[:form]
-    forward = options[:forward]
+  def notes_for(fab, previous_fab, forward)
+    notes = fab.notes.select {|n| n.forward == forward}
+    autofills = forward ? [] : [previous_fab.try(:forward).try(:map, &:body)].flatten
+    notes.zip(autofills)
+  end
 
-    render partial: 'display_fab_note_inputs', locals: {f: form, forward: forward}
+  def header_for(forward)
+    (forward ? "Next Week" : "Last Week").capitalize
   end
 
   def show_fab_notes(options)

--- a/app/models/fab.rb
+++ b/app/models/fab.rb
@@ -12,62 +12,14 @@ class Fab < ActiveRecord::Base
   has_many :forward, -> { where(forward: true).order(:id) }, class_name: "Note"
   has_many :backward, -> { where(forward: false).order(:id) }, class_name: "Note"
 
-
   accepts_nested_attributes_for :notes, reject_if: :all_blank, :allow_destroy => true
 
   after_initialize :setup_children
-
-  def self.find_or_build_this_periods_fab
-    fab_attrs = {period: get_start_of_current_fab_period..get_start_of_current_fab_period+6.days}
-    self.where(fab_attrs).first || self.new(period: get_start_of_current_fab_period)
-  end
-
-  # careful to only call this when you know the user doesn't have a fab this period...
-  def self.build_this_periods_fab
-    self.new(period: get_start_of_current_fab_period)
-  end
-
-  # If it's Thursday, should return the date of two mondays ago
-  # if it's Friday, it should return the monday of the current week!!!
-  def self.get_start_of_current_fab_period
-    # should we show the old fab or a new one
-    start_day = if within_edit_period_of_old_fab?
-      # return the date for the prior week's fab entry so...
-      # (go back 7 days, then go forward until the first Monday) (potentially jumping back more than 7 days!)
-      (DateTime.now.in_time_zone.midnight - 2.week)
-    else
-      # return the date for the current weeks fab entry so...
-      # (go back 7 days from now, then go forward until the first Monday)
-      (DateTime.now.in_time_zone.midnight - 1.week)
-    end
-
-    start_day = advance_to_the_next_period_beginning(start_day)
-  end
-
-  def self.n_hours_until_fab_due
-    ActiveSupport::TimeZone[ENV['time_zone']].parse(ENV['fab_due_time']).hour
-  end
-
-  def self.get_on_time_range_for_period(start_of_period)
-    hours_until_due = n_hours_until_fab_due
-    (start_of_period..start_of_period+1.week+hours_until_due.hours)
-  end
-
-  def self.get_fab_state_for_period(target_period = Fab.get_start_of_current_fab_period)
-    User.fab_still_missing_for_someone?(target_period) ? :someone_on_staff_missed_fab : :happy_fab_cake_time
-  end
 
   def to_s
     forwards = forward.collect {|n| n.body}.join(", ")
     backwards = backward.collect {|n| n.body}.join(", ")
     " Backwards: #{backwards} \n Forwards: #{forwards}"
-  end
-
-  def setup_children
-    if new_record? and notes.empty?
-      3.times { notes.build(forward: true) }
-      3.times { notes.build(forward: false) }
-    end
   end
 
   def expose_notes(direction)
@@ -101,50 +53,105 @@ class Fab < ActiveRecord::Base
   end
 
   def display_date_for_header
-    self.period.strftime("%b %-d ") + "-" + (self.period + 4.days).strftime(" %-d")
+    period.strftime("%b %-d ") + "-" + (period + 4.days).strftime(" %-d")
   end
 
   # this function can be used as a seek forward and will skip blank fabs
   def previous_fab
-    self.user.fabs.where('period < ?', self.period).first
+    user.fabs.where('period < ?', period).first
   end
 
   # this function can be used as a seek forward
   def next_fab
-    fab = self.user.fabs.where('period > ?', self.period).last
+    user.fabs.where('period > ?', period).last
   end
 
-  # this function tries to return the exact next fab for the user, or returns nil
+  # this function returns the exact next fab for the user, or nil
   def exactly_next_fab(include_hypothetical_fab = true)
-    fab = self.user.fabs.where(period: period+1.week-1.day..period+2.weeks-1.day).last
-    fab = self.user.fabs.build(period: period+1.week) if include_hypothetical_fab and fab.nil?
+    fab = user.fabs.where(period: period+1.week-1.day..period+2.weeks-1.day).last
+    fab ||= user.fabs.build(period: period+1.week) if include_hypothetical_fab
     fab
   end
 
-  # this function tries to return the exact previous fab for the user, or returns nil
+  # this function returns the exact previous fab for the user, or nil
   def exactly_previous_fab(include_hypothetical_fab = true)
-    fab = self.user.fabs.where(period: period+1.day-2.week..period+1.day-1.week).last
-    fab = self.user.fabs.build(period: period-1.week) if include_hypothetical_fab and fab.nil?
+    fab = user.fabs.where(period: period+1.day-2.week..period+1.day-1.week).last
+    fab ||= user.fabs.build(period: period-1.week) if include_hypothetical_fab
     fab
   end
 
-
-  # returns an array of two, indicating true or false whether there's a previos
+  # returns an array of two, indicating true or false whether there's a previous
   # or next fab relative to the fab_id supplied
   def which_neighbor_fabs_exist?
-    [!self.previous_fab.nil?, !self.next_fab.nil?]
+    [!previous_fab.nil?, !next_fab.nil?]
   end
 
-  def self.advance_to_the_next_period_beginning(given_day)
-    desired_wday = Date.parse(ENV['fab_starting_day']).wday
-    current_date_progress = given_day
+  private
 
-    until current_date_progress.wday == desired_wday do
-      current_date_progress = current_date_progress.advance days: 1
+  def display_start_day_of_week(p_start)
+    ist_of_month = p_start.strftime("%e").to_i.ordinalize
+    p_start.strftime("Week of %B #{ist_of_month}, %Y")
+  end
+
+  def setup_children
+    if new_record? and notes.empty?
+      3.times { notes.build(forward: true) }
+      3.times { notes.build(forward: false) }
+    end
+  end
+
+  class << self
+  public
+    def advance_to_the_next_period_beginning(given_day)
+      desired_wday = Date.parse(ENV['fab_starting_day']).wday
+      current_date_progress = given_day
+
+      until current_date_progress.wday == desired_wday do
+        current_date_progress = current_date_progress.advance days: 1
+      end
+
+      current_date_progress
     end
 
-    current_date_progress
-  end
+    def find_or_build_this_periods_fab
+      fab_attrs = {period: get_start_of_current_fab_period..get_start_of_current_fab_period+6.days}
+      self.where(fab_attrs).first || self.new(period: get_start_of_current_fab_period)
+    end
+
+    # careful to only call this when you know the user doesn't have a fab this period...
+    def build_this_periods_fab
+      self.new(period: get_start_of_current_fab_period)
+    end
+
+    # If it's Thursday, should return the date of two mondays ago
+    # if it's Friday, it should return the monday of the current week!!!
+    def get_start_of_current_fab_period
+      # should we show the old fab or a new one
+      start_day = if within_edit_period_of_old_fab?
+        # return the date for the prior week's fab entry so...
+        # (go back 7 days, then go forward until the first Monday) (potentially jumping back more than 7 days!)
+        (DateTime.now.in_time_zone.midnight - 2.week)
+      else
+        # return the date for the current weeks fab entry so...
+        # (go back 7 days from now, then go forward until the first Monday)
+        (DateTime.now.in_time_zone.midnight - 1.week)
+      end
+
+      start_day = advance_to_the_next_period_beginning(start_day)
+    end
+
+    def n_hours_until_fab_due
+      ActiveSupport::TimeZone[ENV['time_zone']].parse(ENV['fab_due_time']).hour
+    end
+
+    def get_on_time_range_for_period(start_of_period)
+      hours_until_due = n_hours_until_fab_due
+      (start_of_period..start_of_period+1.week+hours_until_due.hours)
+    end
+
+    def get_fab_state_for_period(target_period = Fab.get_start_of_current_fab_period)
+      User.fab_still_missing_for_someone?(target_period) ? :someone_on_staff_missed_fab : :happy_fab_cake_time
+    end
 
   private
 
@@ -156,7 +163,7 @@ class Fab < ActiveRecord::Base
     # recent monday.
     # If it's mon, tuesday, wed, thrs, then jump back 2 mondays
     # else if it's fri, sat, sun, mon, jump back 1 single monday
-    def self.within_edit_period_of_old_fab?
+    def within_edit_period_of_old_fab?
       week_of_days = [0,1,2,3,4,5,6]
 
       starting_day_of_week = Date.parse(ENV['fab_starting_day']).wday
@@ -170,16 +177,7 @@ class Fab < ActiveRecord::Base
       jump_back_two_monday_days = rotated_week[0...3]
       # jump_back_single_monday_days = rotated_week[4..-1]
 
-      if jump_back_two_monday_days.include?(DateTime.now.in_time_zone.wday)
-        true
-      else
-        false
-      end
+      jump_back_two_monday_days.include?(DateTime.now.in_time_zone.wday)
     end
-
-    def display_start_day_of_week(p_start)
-      ist_of_month = p_start.strftime("%e").to_i.ordinalize
-      p_start.strftime("Week of %B #{ist_of_month}, %Y")
-    end
-
+  end
 end

--- a/app/views/fabs/_display_fab_note_inputs.html.erb
+++ b/app/views/fabs/_display_fab_note_inputs.html.erb
@@ -1,27 +1,17 @@
 <% title = forward ? 'forward' : 'back' %>
-<% start_day = @fab.send("display_#{title}_start_day") %>
-
-<% if @fab.id.nil? %>
-  <% notes = forward ? @fab.notes.select {|n| n.forward} : @fab.notes.select {|n| !n.forward} %>
-<% else %>
-  <% notes = forward ? @fab.forward : @fab.backward %>
-<% end %>
-
-<% placeholders = forward ? [] : @previous_fab.try(:forward).try(:map, &:body) || [] %>
-
-<% week_back_forward = forward ? "Next Week" : "Last Week" %>
-
 <div class="fab-note-inputs <%= title %>">
-  <h3><%= week_back_forward.capitalize %></h3>
+  <h3>
+    <%= header_for(forward) %>
+  </h3>
   <h4>
-    <%= start_day %>
+    <%= @fab.send("display_#{title}_start_day") %>
   </h4>
 
-  <% notes.zip(placeholders).each do |note, placeholder| %>
+  <% notes_for(@fab, @previous_fab, forward).each do |note, autofill| %>
     <div class="nested-fields"</div>
       <%= f.fields_for(:notes, note) do |f| %>
         <%= f.hidden_field :forward, value: note.forward %>
-        <%= f.text_field :body, placeholder: placeholder %>
+        <%= f.text_field :body, value: note.body || autofill %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/fabs/_form.html.erb
+++ b/app/views/fabs/_form.html.erb
@@ -5,10 +5,9 @@
     <div class="form-inputs">
 
       <div class="clear"></div>
-      <%= display_fab_note_inputs form: f, forward: false %>
-      <%= display_fab_note_inputs form: f, forward: true %>
+      <%= render partial: 'display_fab_note_inputs', locals: {f: f, forward: false} %>
+      <%= render partial: 'display_fab_note_inputs', locals: {f: f, forward: true} %>
       <div class="clear"></div>
-
 
       <!-- <div>Gif Tag:
         <%= f.file_field :gif_tag %>

--- a/app/views/fabs/_index_fab_back.html.erb
+++ b/app/views/fabs/_index_fab_back.html.erb
@@ -1,8 +1,9 @@
 <% time_span = fab.display_date_for_header %>
 
-<div>
+<div class="fab-notes">
   <h3><%= link_to time_span, [@user, fab] %> </h3>
-  <% fab.backward.each do |note| %>
-    <div class="fab-notes"><%= note.body %></div>
+  <% backward_or_placeholders(fab).each do |note| %>
+    <%= note %>
+    <br />
   <% end %>
 </div>

--- a/spec/factories/fabs.rb
+++ b/spec/factories/fabs.rb
@@ -4,17 +4,21 @@ FactoryGirl.define do
   end
 
   factory :fab_due_in_prior_period, parent: :fab do
-    after(:create) do |fab|
+    before(:create) do |fab|
       fab.period = (Fab.get_start_of_current_fab_period - 7.days)
       fab.created_at = fab.period
+    end
+    after(:create) do |fab|
       fab.backward.first.update_attributes(body: "I have an old note")
     end
   end
 
   factory :fab_due_in_current_period, parent: :fab do
-    after(:create) do |fab|
+    before(:create) do |fab|
       fab.period = (Fab.get_start_of_current_fab_period)
       fab.created_at = fab.period
+    end
+    after(:create) do |fab|
       fab.backward.first.update_attributes(body: "I have a note")
     end
   end


### PR DESCRIPTION
Our user has never missed a FAB, but the list on her FABs page shows a series of empty weeks!  Where did her FABs go?

It turns out that when our user fills out her FAB, she only enters new info for the "Forward" part.  She doesn't fill out the "Back" part, because those fields are autopopulated from last week's "Forward." But alas, those are only placeholders, so they don't get saved to the new FAB.  Hence, empty list.

Everyone I talked to agreed that we should save the autopopulated fields to the new FAB.  That may have something to do with the fact that everyone I talked to had empty historical lists.