### PR TITLE
Send info about failed wherebot imports to Sentry

### DIFF
--- a/lib/wherebot.rb
+++ b/lib/wherebot.rb
@@ -86,8 +86,9 @@ class Wherebot
 
       destroy_message if wm.save!
     rescue => e
-      Raven.extra_context(email: from, subject: subject, body: body)
-      Raven.captureException(e)
+      Raven.captureException(
+        e, extra: { email: from, subject: subject, body: body }.to_json
+      )
       false
     end
 


### PR DESCRIPTION
Args sent through extra_context don't show up in Sentry, apparently.