### PR TITLE
Change the wording of the FAB headline

### DIFF
--- a/app/assets/stylesheets/styles/main.scss
+++ b/app/assets/stylesheets/styles/main.scss
@@ -33,7 +33,7 @@
   z-index: 5;
   @include container(70%);
   @include susy-breakpoint($md) {
-    @include container(95%);
+    width: 95%;
   }
   h1 {
     color: #fff;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_hero
-    @hero_text = "Where are your coworkers located on the time/space continuum, and what are they doing now?"
+    @hero_text = "What are your coworkers up to this week?"
     @hero_title = "Forward & Back"
     @hero_image = ActionController::Base.helpers.asset_path('forward-text-white.svg')
   end

--- a/spec/features/users/user_fabs_spec.rb
+++ b/spec/features/users/user_fabs_spec.rb
@@ -16,7 +16,7 @@ feature 'User fabs page', :devise do
     visit user_fabs_path(@me)
 
     expect(page.find("#hero h1")).to have_content(
-      "Where are your coworkers located on the time/space continuum, and what are they doing now?"
+      "What are your coworkers up to this week?"
     )
     expect(page.find("#front img")["src"]).to match(/forward-text-white/)
     expect(page.find("#front img")["alt"]).to eq("Forward & Back")


### PR DESCRIPTION
When we started Whereabouts, Hugh and I talked about splitting the headline between FAB and Whereabouts.  I remembered to add the Whereabouts headline, but i forgot to change the default text.
Includes a style change to make it work on large screens.

FABs at many sizes:
![fab-big](https://user-images.githubusercontent.com/1065956/40754308-83682f5a-642d-11e8-83c2-8e2bc9d38fae.png)
![fab-med](https://user-images.githubusercontent.com/1065956/40754309-83822f0e-642d-11e8-9e98-29ae27b214d0.png)
![fab-small](https://user-images.githubusercontent.com/1065956/40754310-839e14a8-642d-11e8-9729-e063405965fb.png)
![fab-tiny](https://user-images.githubusercontent.com/1065956/40754311-83b88b30-642d-11e8-8718-33ae93ed76be.png)

Whereabouts at many sizes:
![where-big](https://user-images.githubusercontent.com/1065956/40754317-986b78b2-642d-11e8-96be-d78560f73eff.png)
![where-med](https://user-images.githubusercontent.com/1065956/40754318-989990e4-642d-11e8-90be-b95782153942.png)
![where-small](https://user-images.githubusercontent.com/1065956/40754319-98b5c908-642d-11e8-8a01-6cd04ff7eca5.png)
![where-tiny](https://user-images.githubusercontent.com/1065956/40754320-98d2b84c-642d-11e8-97f4-758ce1279e58.png)
